### PR TITLE
Install Docker Desktop on macOS

### DIFF
--- a/priv/static/macOS.sh
+++ b/priv/static/macOS.sh
@@ -138,7 +138,7 @@ function install() {
         asdf reshim chromedriver latest
         ;;
     "Docker")
-        brew install docker
+        brew install --cask docker
         ;;
     *)
         echo "Invalid name argument on install"


### PR DESCRIPTION
Docker on Mac is a GUI tool, so you need to use Homebrew Cask for the installation.

If you have ever installed any GUI software on Mac the “standard way,” you probably know that it normally requires downloading the package, opening it, and installing by the drag-and-drop method to the Application folder. Homebrew, by default, can only install command-line tools.

Homebrew Cask is a Homebrew extension for installing GUI software on Mac. It means that instead of the standard download and drag-and-drop process, you can use this (to install Docker in this case):
`brew install --cask docker`

Referrence: https://www.cprime.com/resources/blog/docker-for-mac-with-homebrew-a-step-by-step-tutorial/