### PR TITLE
Reduce cache saving time

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,12 +18,13 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - name: Restore dependencies cache
+        uses: actions/cache/restore@v4
         with:
+          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           path: |
             _build
             deps
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-
       - name: Install Elixir dependencies
@@ -34,6 +35,13 @@ jobs:
         env:
           MIX_ENV: test
         run: mix compile
+      - name: Save dependencies cache
+        uses: actions/cache/save@v4
+        with:
+          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
+          path: |
+            _build
+            deps
   credo:
     needs: compile
     name: Credo
@@ -47,12 +55,13 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - name: Restore dependencies cache
+        uses: actions/cache/restore@v4
         with:
+          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           path: |
             _build
             deps
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-
       - name: Check code style
@@ -72,12 +81,13 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - name: Restore dependencies cache
+        uses: actions/cache/restore@v4
         with:
+          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           path: |
             _build
             deps
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-
       - name: Check for vulnerable Mix dependencies
@@ -97,19 +107,20 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - name: Restore dependencies cache
+        uses: actions/cache/restore@v4
         with:
+          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           path: |
             _build
             deps
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-
       - name: Restore PLT cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v4
         with:
-          path: priv/plts
           key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-plt-${{ github.sha }}
+          path: priv/plts
           restore-keys: |
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-plt-
       - name: Create PLTs
@@ -120,6 +131,11 @@ jobs:
         env:
           MIX_ENV: test
         run: mix dialyzer
+      - name: Save PLT cache
+        uses: actions/cache/save@v4
+        with:
+          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-plt-${{ github.sha }}
+          path: priv/plts
   format:
     needs: compile
     name: Format
@@ -133,12 +149,13 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - name: Restore dependencies cache
+        uses: actions/cache/restore@v4
         with:
+          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           path: |
             _build
             deps
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-
       - name: Check Elixir formatting
@@ -158,12 +175,13 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - name: Restore dependencies cache
+        uses: actions/cache/restore@v4
         with:
+          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           path: |
             _build
             deps
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-
       - name: Check for retired Hex packages
@@ -177,7 +195,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Restore npm cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v4
         id: npm-cache
         with:
           path: node_modules
@@ -187,6 +205,11 @@ jobs:
         run: npm i -D prettier prettier-plugin-toml
       - name: Run Prettier
         run: npx prettier -c .
+      - name: Save npm cache
+        uses: actions/cache/save@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-prettier
   sobelow:
     needs: compile
     name: Security check
@@ -200,12 +223,13 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - name: Restore dependencies cache
+        uses: actions/cache/restore@v4
         with:
+          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           path: |
             _build
             deps
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-
       - name: Check for security issues using sobelow
@@ -225,12 +249,13 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - name: Restore dependencies cache
+        uses: actions/cache/restore@v4
         with:
+          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           path: |
             _build
             deps
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-
       - name: Run tests
@@ -250,12 +275,13 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - name: Restore dependencies cache
+        uses: actions/cache/restore@v4
         with:
+          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           path: |
             _build
             deps
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-
       - name: Check for unused Mix dependencies

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,12 +22,13 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - name: Restore dependencies cache
+        uses: actions/cache/restore@v4
         with:
+          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           path: |
             _build
             deps
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-
       - name: Install Elixir dependencies
@@ -38,6 +39,13 @@ jobs:
         env:
           MIX_ENV: test
         run: mix compile
+      - name: Save dependencies cache
+        uses: actions/cache/save@v4
+        with:
+          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
+          path: |
+            _build
+            deps
   credo:
     needs: compile
     name: Credo
@@ -51,12 +59,13 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - name: Restore dependencies cache
+        uses: actions/cache/restore@v4
         with:
+          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           path: |
             _build
             deps
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-
       - name: Check code style
@@ -76,12 +85,13 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - name: Restore dependencies cache
+        uses: actions/cache/restore@v4
         with:
+          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           path: |
             _build
             deps
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-
       - name: Check for vulnerable Mix dependencies
@@ -101,19 +111,20 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - name: Restore dependencies cache
+        uses: actions/cache/restore@v4
         with:
+          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           path: |
             _build
             deps
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-
       - name: Restore PLT cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v4
         with:
-          path: priv/plts
           key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-plt-${{ github.sha }}
+          path: priv/plts
           restore-keys: |
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-plt-
       - name: Create PLTs
@@ -124,6 +135,11 @@ jobs:
         env:
           MIX_ENV: test
         run: mix dialyzer
+      - name: Save PLT cache
+        uses: actions/cache/save@v4
+        with:
+          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-plt-${{ github.sha }}
+          path: priv/plts
   format:
     needs: compile
     name: Format
@@ -137,12 +153,13 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - name: Restore dependencies cache
+        uses: actions/cache/restore@v4
         with:
+          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           path: |
             _build
             deps
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-
       - name: Check Elixir formatting
@@ -162,12 +179,13 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - name: Restore dependencies cache
+        uses: actions/cache/restore@v4
         with:
+          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           path: |
             _build
             deps
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-
       - name: Check for retired Hex packages
@@ -181,7 +199,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Restore npm cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v4
         id: npm-cache
         with:
           path: node_modules
@@ -191,6 +209,11 @@ jobs:
         run: npm i -D prettier prettier-plugin-toml
       - name: Run Prettier
         run: npx prettier -c .
+      - name: Save npm cache
+        uses: actions/cache/save@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-prettier
   sobelow:
     needs: compile
     name: Security check
@@ -204,12 +227,13 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - name: Restore dependencies cache
+        uses: actions/cache/restore@v4
         with:
+          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           path: |
             _build
             deps
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-
       - name: Check for security issues using sobelow
@@ -229,12 +253,13 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - name: Restore dependencies cache
+        uses: actions/cache/restore@v4
         with:
+          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           path: |
             _build
             deps
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-
       - name: Run tests
@@ -254,12 +279,13 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
-      - uses: actions/cache@v3
+      - name: Restore dependencies cache
+        uses: actions/cache/restore@v4
         with:
+          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           path: |
             _build
             deps
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-mix-
       - name: Check for unused Mix dependencies


### PR DESCRIPTION
There is a bug in GitHub Actions which recently started causing saving cache to slow down the whole workflow. Separating cache into restore and save steps fixes it.

Source:
https://github.com/actions/toolkit/issues/1578#issuecomment-2253355054

### Mix deps
Before:
<img width="899" alt="Screenshot 2024-11-29 at 13 51 31" src="https://github.com/user-attachments/assets/ea092e5e-b41f-4bf7-8510-8260ae747698">
https://github.com/optimumBA/phx.tools/actions/runs/11973109820/job/33381360898

After:
<img width="898" alt="Screenshot 2024-11-29 at 13 50 46" src="https://github.com/user-attachments/assets/4b4c123d-f5bf-4296-a901-020a5eb91387">
https://github.com/optimumBA/phx.tools/actions/runs/12085003157/job/33701340805

### PLT
Before: 
<img width="903" alt="Screenshot 2024-11-29 at 13 51 59" src="https://github.com/user-attachments/assets/8863ae95-ff53-4bb9-bf1a-d31c0f9adae2">
https://github.com/optimumBA/phx.tools/actions/runs/11973109820/job/33381485553

After:
<img width="902" alt="Screenshot 2024-11-29 at 13 50 56" src="https://github.com/user-attachments/assets/2705c3d0-65e9-41d4-95c1-fdd1502a3c63">
https://github.com/optimumBA/phx.tools/actions/runs/12085003157/job/33701356820